### PR TITLE
expose parser recognizer errors 

### DIFF
--- a/src/exoscale/cel/antlr.clj
+++ b/src/exoscale/cel/antlr.clj
@@ -1,30 +1,55 @@
 (ns ^:no-doc exoscale.cel.antlr
   "Antlr interop"
-  (:import exoscale.cel.CELParser
-           exoscale.cel.CELLexer
-           org.antlr.v4.runtime.CharStreams
-           org.antlr.v4.runtime.CharStream
-           org.antlr.v4.runtime.CommonTokenStream
-           org.antlr.v4.runtime.BaseErrorListener))
+  (:import (exoscale.cel CELParser CELLexer)
+           (org.antlr.v4.runtime Parser
+                                 CharStream
+                                 CharStreams
+                                 CommonTokenStream
+                                 BaseErrorListener
+                                 RecognitionException)))
+
+;; recognition-exception->map is shamelessly borrowed from clj-antlr
+;; https://github.com/aphyr/clj-antlr
+(defn recognition-exception->map
+  "Converts a RecognitionException to a nice readable map."
+  [^RecognitionException e]
+  {:rule (.getCtx e)
+   :state (.getOffendingState e)
+   :expected (try (.getExpectedTokens e)
+                  (catch IllegalArgumentException _
+                    ; I think ANTLR throws here for
+                    ; tokenizer errors.
+                    nil))
+   :token (.getOffendingToken e)})
 
 (defn- error-listener
   "Error listener for the parser"
   [state]
   (proxy [BaseErrorListener] []
     (syntaxError [recognizer offending-symbol line char msg ex]
-      (vswap! state conj {:line line :char char :msg msg}))))
+      (vswap! state
+              conj
+              (cond-> {:symbol offending-symbol
+                       :line line
+                       :char char
+                       :msg msg}
+                (instance? Parser recognizer)
+                (assoc :stack (-> recognizer .getRuleInvocationStack reverse))
+                (some? ex)
+                (into (recognition-exception->map ex)))))))
 
 (defn make-program
   "Build a program from the given input string. Throws for invalid
    expressions."
   [input]
-  (let [cs     ^CharStream (CharStreams/fromString (str input))
-        state  (volatile! [])
-        lexer  (CELLexer. cs)
-        ts     (CommonTokenStream. lexer)
-        parser (doto (CELParser. ts)
-                 (.addErrorListener (error-listener state)))
-        tree   (.start parser)]
+  (let [cs ^CharStream (CharStreams/fromString (str input))
+        state (volatile! [])
+        err-listener (error-listener state)
+        lexer (doto (CELLexer. cs)
+                (.addErrorListener err-listener))
+        ts (CommonTokenStream. lexer)
+        parser (doto (CELParser. ts) (.addErrorListener err-listener))
+        tree (.start parser)]
     (when (seq @state)
       (throw (ex-info "unable to parse CEL expression" {:errors @state})))
     tree))

--- a/test/exoscale/cel/errors_test.clj
+++ b/test/exoscale/cel/errors_test.clj
@@ -1,7 +1,10 @@
 (ns exoscale.cel.errors-test
-  (:require [clojure.test :as t :refer [deftest is]]))
+  (:require [clojure.test :as t :refer [deftest is]]
+            [exoscale.cel.parser :as parser]))
 
 (deftest test-errors
-
-  (is true))
-
+  (testing "invalid syntax"
+    (try (parser/parse-eval {} "can't parse this")
+         (catch Exception e
+           (is (-> e ex-data :errors first :msg
+                   (= "token recognition error at: ''t parse this'")))))))

--- a/test/exoscale/cel/errors_test.clj
+++ b/test/exoscale/cel/errors_test.clj
@@ -1,0 +1,7 @@
+(ns exoscale.cel.errors-test
+  (:require [clojure.test :as t :refer [deftest is]]))
+
+(deftest test-errors
+
+  (is true))
+

--- a/test/exoscale/cel/errors_test.clj
+++ b/test/exoscale/cel/errors_test.clj
@@ -1,5 +1,5 @@
 (ns exoscale.cel.errors-test
-  (:require [clojure.test :as t :refer [deftest is]]
+  (:require [clojure.test :refer [deftest is testing]]
             [exoscale.cel.parser :as parser]))
 
 (deftest test-errors


### PR DESCRIPTION
Turns the current "no such attribute" error into something that has more meaning in these cases:

for 

```clj
 (parser/parse-eval {} "can't parse this")
```

before:

```clj
#error {
 :cause "no such attribute"
 :data {}
 :via
 [{:type clojure.lang.ExceptionInfo
   :message "no such attribute"
   :data {}
   :at [exoscale.cel.expr.ErrorType unwrap "expr.clj" 54]}]
 :trace
 [...]}
```
after:

```clj
   Unable to parse CEL expression
   {:exoscale.ex/type :exoscale.ex/fault,
    :errors
    [{:msg "token recognition error at: ''t parse this'",
      :line 1,
      :char 3,
      :state -1}]}
```