### PR TITLE
ensure getHours return 24 formatted hours

### DIFF
--- a/src/exoscale/cel/expr.clj
+++ b/src/exoscale/cel/expr.clj
@@ -738,7 +738,7 @@
                            (java.util.TimeZone/getTimeZone
                             (str (val tz))))
                       (.setTime (val t)))]
-       (IntType. (.get calendar java.util.Calendar/HOUR)))
+       (IntType. (.get calendar java.util.Calendar/HOUR_OF_DAY)))
      (catch Exception e
        (ErrorType. (ex-message e))))))
 

--- a/test/exoscale/cel/timestamps_test.clj
+++ b/test/exoscale/cel/timestamps_test.clj
@@ -1,0 +1,15 @@
+(ns exoscale.cel.timestamps-test
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [exoscale.cel.parser :as parser]
+   [exoscale.cel.test-helper :as helper]))
+
+(deftest ensure-datetime-conversion-24
+  (testing
+   "Ensure that getHours returns 24 formated hours"
+    (is (-> (parser/parse-eval
+             {:bindings (helper/bindings nil), :translate-result? false}
+             "timestamp('2009-02-13T23:31:30Z').getHours()")
+            :x
+            (= 23)))))
+


### PR DESCRIPTION
Added a new test ns for timestamps since we rely on the generated ones for most things atm. 
The generated ones give pretty good coverage already: see exoscale.cel.generated.timestamps-test