### PR TITLE
bugfix: ensure map contains check uses (val...) to unwrap equals? result

### DIFF
--- a/src/exoscale/cel/expr.clj
+++ b/src/exoscale/cel/expr.clj
@@ -318,7 +318,7 @@
                    (let [v1 (get entries k)
                          v2 (get other-entries k)]
                      (or (and (= (typeof v1) (typeof v2))
-                              (val (equal? v1 v2)))
+                              (:x (equal? v1 v2)))
                          (reduced false))))
                  true
                  (set (concat entries-keys other-entries-keys)))))))
@@ -332,7 +332,7 @@
           found? (reduce (fn [a entry]
                            (let [candidate (key entry)]
                              (if (and (= (typeof candidate) (typeof e))
-                                      (equal? candidate e))
+                                      (val (equal? candidate e)))
                                (reduced true)
                                a)))
                          false

--- a/test/exoscale/cel/map_test.clj
+++ b/test/exoscale/cel/map_test.clj
@@ -1,0 +1,66 @@
+(ns exoscale.cel.map-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [exoscale.cel.parser :as parser]
+            [exoscale.cel.test-helper :as helper]))
+
+(deftest test-operator-in
+  (let [abc->cde (helper/bindings {:headers {:value {:mapValue {:entries [{:key   {:stringValue "abc"}
+                                                                           :value {:stringValue "cde"}}
+
+                                                                          {:key   {:stringValue "with-dashes"}
+                                                                           :value {:stringValue "cde"}}]}}}})]
+    (testing "non-dashed value"
+      (testing "value does not exist"
+        (is (not (parser/parse-eval {:bindings          abc->cde
+                                     :throw-on-error?   true
+                                     :translate-result? true}
+                                    "('xxx' in headers)"))))
+
+      (testing "value exists"
+        (is (parser/parse-eval {:bindings          abc->cde
+                                :throw-on-error?   true
+                                :translate-result? true}
+                               "('abc' in headers)"))))
+
+    (testing "value with dashes"
+      (testing "value does not exist"
+        (is (not (parser/parse-eval {:bindings          abc->cde
+                                     :throw-on-error?   true
+                                     :translate-result? true}
+                                    "('some-header' in headers)"))))
+
+      (testing "value exists"
+        (is (parser/parse-eval {:bindings          abc->cde
+                                :throw-on-error?   true
+                                :translate-result? true}
+                               "('with-dashes' in headers)"))))))
+
+(deftest test-map-has
+  (let [abc->cde (helper/bindings {:headers {:value {:mapValue {:entries [{:key   {:stringValue "abc"}
+                                                                           :value {:stringValue "cde"}}
+
+                                                                          {:key   {:stringValue "with-dashes"}
+                                                                           :value {:stringValue "cde"}}]}}}})]
+    (testing "value exists"
+      (is (parser/parse-eval {:bindings          abc->cde
+                              :throw-on-error?   true
+                              :translate-result? true}
+                             "has(headers.abc)")))))
+
+(deftest test-map-equality
+  (let [abc->cde (helper/bindings {:headers {:value {:mapValue {:entries [{:key   {:stringValue "abc"}
+                                                                           :value {:stringValue "cde"}}
+
+                                                                          {:key   {:stringValue "with-dashes"}
+                                                                           :value {:stringValue "cde"}}]}}}})]
+    (testing "value matches"
+      (is (parser/parse-eval {:bindings          abc->cde
+                              :throw-on-error?   true
+                              :translate-result? true}
+                             "(headers.abc) == 'cde'")))
+
+    (testing "value with dashes matches"
+      (is (parser/parse-eval {:bindings          abc->cde
+                              :throw-on-error?   true
+                              :translate-result? true}
+                             "headers['with-dashes'] == 'cde'")))))


### PR DESCRIPTION
The membership test had a subtle bug in the form:
```
(if (and (= (typeof candidate) (typeof e))
         (equal? candidate e))
```

`equal?` returns a `BoolType` which always evals to `truthy`, hence it must be unwrapped to be usable in an `if`